### PR TITLE
Fix 'multiple definition of ...' linker errors.

### DIFF
--- a/Gamecube/plugins.c
+++ b/Gamecube/plugins.c
@@ -35,6 +35,130 @@ static const char *err;
 static int errval;
 void *hGPUDriver;
 
+//plugin stuff From Shadow
+// *** walking in the valley of your darking soul i realize that i was alone
+//Gpu function pointers
+GPUupdateLace    GPU_updateLace;
+GPUinit          GPU_init;
+GPUshutdown      GPU_shutdown;
+GPUconfigure     GPU_configure;
+GPUtest          GPU_test;
+GPUabout         GPU_about;
+GPUopen          GPU_open;
+GPUclose         GPU_close;
+GPUreadStatus    GPU_readStatus;
+GPUreadData      GPU_readData;
+GPUreadDataMem   GPU_readDataMem;
+GPUwriteStatus   GPU_writeStatus;
+GPUwriteData     GPU_writeData;
+GPUwriteDataMem  GPU_writeDataMem;
+GPUdmaChain      GPU_dmaChain;
+GPUkeypressed    GPU_keypressed;
+GPUdisplayText   GPU_displayText;
+GPUmakeSnapshot  GPU_makeSnapshot;
+GPUfreeze        GPU_freeze;
+GPUgetScreenPic  GPU_getScreenPic;
+GPUshowScreenPic GPU_showScreenPic;
+GPUclearDynarec  GPU_clearDynarec;
+
+//cd rom function pointers
+CDRinit               CDR_init;
+CDRshutdown           CDR_shutdown;
+CDRopen               CDR_open;
+CDRclose              CDR_close;
+CDRtest               CDR_test;
+CDRgetTN              CDR_getTN;
+CDRgetTD              CDR_getTD;
+CDRreadTrack          CDR_readTrack;
+CDRgetBuffer          CDR_getBuffer;
+CDRplay               CDR_play;
+CDRstop               CDR_stop;
+CDRgetStatus          CDR_getStatus;
+CDRgetDriveLetter     CDR_getDriveLetter;
+CDRgetBufferSub       CDR_getBufferSub;
+CDRconfigure          CDR_configure;
+CDRabout              CDR_about;
+CDRsetfilename        CDR_setfilename;
+
+//SPU POINTERS
+SPUconfigure        SPU_configure;
+SPUabout            SPU_about;
+SPUinit             SPU_init;
+SPUshutdown         SPU_shutdown;
+SPUtest             SPU_test;
+SPUopen             SPU_open;
+SPUclose            SPU_close;
+SPUplaySample       SPU_playSample;
+SPUstartChannels1   SPU_startChannels1;
+SPUstartChannels2   SPU_startChannels2;
+SPUstopChannels1    SPU_stopChannels1;
+SPUstopChannels2    SPU_stopChannels2;
+SPUputOne           SPU_putOne;
+SPUgetOne           SPU_getOne;
+SPUsetAddr          SPU_setAddr;
+SPUsetPitch         SPU_setPitch;
+SPUsetVolumeL       SPU_setVolumeL;
+SPUsetVolumeR       SPU_setVolumeR;
+SPUwriteRegister    SPU_writeRegister;
+SPUreadRegister     SPU_readRegister;
+SPUwriteDMA         SPU_writeDMA;
+SPUreadDMA          SPU_readDMA;
+SPUwriteDMAMem      SPU_writeDMAMem;
+SPUreadDMAMem       SPU_readDMAMem;
+SPUplayADPCMchannel SPU_playADPCMchannel;
+SPUfreeze           SPU_freeze;
+SPUregisterCallback SPU_registerCallback;
+SPUregisterCDDAVolume SPU_registerCDDAVolume;
+SPUasync            SPU_async;
+
+//PAD POINTERS
+PADconfigure        PAD1_configure;
+PADabout            PAD1_about;
+PADinit             PAD1_init;
+PADshutdown         PAD1_shutdown;
+PADtest             PAD1_test;
+PADopen             PAD1_open;
+PADclose            PAD1_close;
+PADquery            PAD1_query;
+PADreadPort1        PAD1_readPort1;
+PADkeypressed       PAD1_keypressed;
+PADstartPoll        PAD1_startPoll;
+PADpoll             PAD1_poll;
+PADsetSensitive     PAD1_setSensitive;
+
+PADconfigure        PAD2_configure;
+PADabout            PAD2_about;
+PADinit             PAD2_init;
+PADshutdown         PAD2_shutdown;
+PADtest             PAD2_test;
+PADopen             PAD2_open;
+PADclose            PAD2_close;
+PADquery            PAD2_query;
+PADreadPort2        PAD2_readPort2;
+PADkeypressed       PAD2_keypressed;
+PADstartPoll        PAD2_startPoll;
+PADpoll             PAD2_poll;
+PADsetSensitive     PAD2_setSensitive;
+
+// NET function pointers
+NETinit               NET_init;
+NETshutdown           NET_shutdown;
+NETopen               NET_open;
+NETclose              NET_close;
+NETtest               NET_test;
+NETconfigure          NET_configure;
+NETabout              NET_about;
+NETpause              NET_pause;
+NETresume             NET_resume;
+NETqueryPlayer        NET_queryPlayer;
+NETsendData           NET_sendData;
+NETrecvData           NET_recvData;
+NETsendPadData        NET_sendPadData;
+NETrecvPadData        NET_recvPadData;
+NETsetInfo            NET_setInfo;
+NETkeypressed         NET_keypressed;
+
+
 void ConfigurePlugins();
 
 #if 0 // These are actually in the GPU plugin (and probably work in there )

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ all:
 	@$(ECHO) "Rebuilding Wii and logging to build.log..."
 	@$(MAKE) -C Gamecube clean -f Makefile_Wii
 	@$(MAKE) -C Gamecube -f Makefile_Wii 2> temp.log
-  #This step removes all leading pathes from the build.log
+	#This step removes all leading pathes from the build.log
 	@sed 's|.*wiisxr/Gamecube|/wiisxr/Gamecube|;s|/./|/|;s|\r\n|\n|' temp.log > build.log
-  #note that msys doesn't seem to like sed -i
+	#note that msys doesn't seem to like sed -i
 	@rm temp.log
 
 Wii:

--- a/PeopsGXGPU/swap.h
+++ b/PeopsGXGPU/swap.h
@@ -20,26 +20,26 @@
 
 #ifdef _BIG_ENDIAN
 // GCC style
-extern __inline__ unsigned short GETLE16(unsigned short *ptr) {
+static __inline__ unsigned short GETLE16(unsigned short *ptr) {
     unsigned short ret; __asm__ ("lhbrx %0, 0, %1" : "=r" (ret) : "r" (ptr));
     return ret;
 }
-extern __inline__ unsigned long GETLE32(unsigned long *ptr) {
+static __inline__ unsigned long GETLE32(unsigned long *ptr) {
     unsigned long ret;
     __asm__ ("lwbrx %0, 0, %1" : "=r" (ret) : "r" (ptr));
     return ret;
 }
-extern __inline__ unsigned long GETLE16D(unsigned long *ptr) {
+static __inline__ unsigned long GETLE16D(unsigned long *ptr) {
     unsigned long ret;
     __asm__ ("lwbrx %0, 0, %1\n"
              "rlwinm %0, %0, 16, 0, 31" : "=r" (ret) : "r" (ptr));
     return ret;
 }
 
-extern __inline__ void PUTLE16(unsigned short *ptr, unsigned short val) {
+static __inline__ void PUTLE16(unsigned short *ptr, unsigned short val) {
     __asm__ ("sthbrx %0, 0, %1" : : "r" (val), "r" (ptr) : "memory");
 }
-extern __inline__ void PUTLE32(unsigned long *ptr, unsigned long val) {
+static __inline__ void PUTLE32(unsigned long *ptr, unsigned long val) {
     __asm__ ("stwbrx %0, 0, %1" : : "r" (val), "r" (ptr) : "memory");
 }
 #else // _BIG_ENDIAN

--- a/PeopsSoftGPU/soft.c
+++ b/PeopsSoftGPU/soft.c
@@ -298,7 +298,7 @@ void Dither16(unsigned short * pdest,unsigned long r,unsigned long g,unsigned lo
 /////////////////////////////////////////////////////////////////
 
 //__inline__ void GetShadeTransCol_Dither(unsigned short * pdest,long m1,long m2,long m3) __attribute__ ((__pure__));
-__inline__ void GetShadeTransCol_Dither(unsigned short * pdest,long m1,long m2,long m3)
+static __inline__ void GetShadeTransCol_Dither(unsigned short * pdest,long m1,long m2,long m3)
 {
  long r,g,b;
 
@@ -362,7 +362,7 @@ __inline__ void GetShadeTransCol_Dither(unsigned short * pdest,long m1,long m2,l
 
 ////////////////////////////////////////////////////////////////////////
 //__inline__ void GetShadeTransCol(unsigned short * pdest,unsigned short color) __attribute__ ((__pure__));
-__inline__ void GetShadeTransCol(unsigned short * pdest,unsigned short color)
+static __inline__ void GetShadeTransCol(unsigned short * pdest,unsigned short color)
 {
  if(bCheckMask && (*pdest & HOST2LE16(0x8000))) return;
 
@@ -421,7 +421,7 @@ __inline__ void GetShadeTransCol(unsigned short * pdest,unsigned short color)
 
 ////////////////////////////////////////////////////////////////////////
 //__inline__ void GetShadeTransCol32(unsigned long * pdest,unsigned long color) __attribute__ ((__pure__));
-__inline__ void GetShadeTransCol32(unsigned long * pdest,unsigned long color)
+static __inline__ void GetShadeTransCol32(unsigned long * pdest,unsigned long color)
 {
  if(DrawSemiTrans)
   {
@@ -513,7 +513,7 @@ __inline__ void GetShadeTransCol32(unsigned long * pdest,unsigned long color)
 
 ////////////////////////////////////////////////////////////////////////
 //__inline__ void GetTextureTransColG(unsigned short * pdest,unsigned short color) __attribute__ ((__pure__));
-__inline__ void GetTextureTransColG(unsigned short * pdest,unsigned short color)
+static __inline__ void GetTextureTransColG(unsigned short * pdest,unsigned short color)
 {
  long r,g,b;unsigned short l;
 
@@ -586,7 +586,7 @@ __inline__ void GetTextureTransColG(unsigned short * pdest,unsigned short color)
 
 ////////////////////////////////////////////////////////////////////////
 //__inline__ void GetTextureTransColG_S(unsigned short * pdest,unsigned short color) __attribute__ ((__pure__));
-__inline__ void GetTextureTransColG_S(unsigned short * pdest,unsigned short color)
+static __inline__ void GetTextureTransColG_S(unsigned short * pdest,unsigned short color)
 {
  long r,g,b;unsigned short l;
 
@@ -607,7 +607,7 @@ __inline__ void GetTextureTransColG_S(unsigned short * pdest,unsigned short colo
 
 ////////////////////////////////////////////////////////////////////////
 //__inline__ void GetTextureTransColG_SPR(unsigned short * pdest,unsigned short color) __attribute__ ((__pure__));
-__inline__ void GetTextureTransColG_SPR(unsigned short * pdest,unsigned short color)
+static __inline__ void GetTextureTransColG_SPR(unsigned short * pdest,unsigned short color)
 {
  long r,g,b;unsigned short l;
 
@@ -680,7 +680,7 @@ __inline__ void GetTextureTransColG_SPR(unsigned short * pdest,unsigned short co
 
 ////////////////////////////////////////////////////////////////////////
 //__inline__ void GetTextureTransColG32(unsigned long * pdest,unsigned long color) __attribute__ ((__pure__));
-__inline__ void GetTextureTransColG32(unsigned long * pdest,unsigned long color)
+static __inline__ void GetTextureTransColG32(unsigned long * pdest,unsigned long color)
 {
  long r,g,b,l;
 
@@ -784,7 +784,7 @@ __inline__ void GetTextureTransColG32(unsigned long * pdest,unsigned long color)
 
 ////////////////////////////////////////////////////////////////////////
 //__inline__ void GetTextureTransColG32_S(unsigned long * pdest,unsigned long color) __attribute__ ((__pure__));
-__inline__ void GetTextureTransColG32_S(unsigned long * pdest,unsigned long color)
+static __inline__ void GetTextureTransColG32_S(unsigned long * pdest,unsigned long color)
 {
  long r,g,b;
 
@@ -809,7 +809,7 @@ __inline__ void GetTextureTransColG32_S(unsigned long * pdest,unsigned long colo
 
 ////////////////////////////////////////////////////////////////////////
 //__inline__ void GetTextureTransColG32_SPR(unsigned long * pdest,unsigned long color) __attribute__ ((__pure__));
-__inline__ void GetTextureTransColG32_SPR(unsigned long * pdest,unsigned long color)
+static __inline__ void GetTextureTransColG32_SPR(unsigned long * pdest,unsigned long color)
 {
  long r,g,b;
 
@@ -911,7 +911,7 @@ __inline__ void GetTextureTransColG32_SPR(unsigned long * pdest,unsigned long co
 
 ////////////////////////////////////////////////////////////////////////
 //__inline__ void GetTextureTransColGX_Dither(unsigned short * pdest,unsigned short color,long m1,long m2,long m3) __attribute__ ((__pure__));
-__inline__ void GetTextureTransColGX_Dither(unsigned short * pdest,unsigned short color,long m1,long m2,long m3)
+static __inline__ void GetTextureTransColGX_Dither(unsigned short * pdest,unsigned short color,long m1,long m2,long m3)
 {
  long r,g,b;
 
@@ -982,7 +982,7 @@ __inline__ void GetTextureTransColGX_Dither(unsigned short * pdest,unsigned shor
 
 ////////////////////////////////////////////////////////////////////////
 //__inline__ void GetTextureTransColGX(unsigned short * pdest,unsigned short color,short m1,short m2,short m3) __attribute__ ((__pure__));
-__inline__ void GetTextureTransColGX(unsigned short * pdest,unsigned short color,short m1,short m2,short m3)
+static __inline__ void GetTextureTransColGX(unsigned short * pdest,unsigned short color,short m1,short m2,short m3)
 {
  long r,g,b;unsigned short l;
 
@@ -1054,7 +1054,7 @@ __inline__ void GetTextureTransColGX(unsigned short * pdest,unsigned short color
 
 ////////////////////////////////////////////////////////////////////////
 //__inline__ void GetTextureTransColGX_S(unsigned short * pdest,unsigned short color,short m1,short m2,short m3) __attribute__ ((__pure__));
-__inline__ void GetTextureTransColGX_S(unsigned short * pdest,unsigned short color,short m1,short m2,short m3)
+static __inline__ void GetTextureTransColGX_S(unsigned short * pdest,unsigned short color,short m1,short m2,short m3)
 {
  long r,g,b;
 
@@ -1073,7 +1073,7 @@ __inline__ void GetTextureTransColGX_S(unsigned short * pdest,unsigned short col
 
 ////////////////////////////////////////////////////////////////////////
 //__inline__ void GetTextureTransColGX32_S(unsigned long * pdest,unsigned long color,short m1,short m2,short m3) __attribute__ ((__pure__));
-__inline__ void GetTextureTransColGX32_S(unsigned long * pdest,unsigned long color,short m1,short m2,short m3)
+static __inline__ void GetTextureTransColGX32_S(unsigned long * pdest,unsigned long color,short m1,short m2,short m3)
 {
  long r,g,b;
  

--- a/PeopsSoftGPU/swap.h
+++ b/PeopsSoftGPU/swap.h
@@ -20,26 +20,26 @@
 
 #ifdef _BIG_ENDIAN
 // GCC style
-extern __inline__ unsigned short GETLE16(unsigned short *ptr) {
+static __inline__ unsigned short GETLE16(unsigned short *ptr) {
     unsigned short ret; __asm__ ("lhbrx %0, 0, %1" : "=r" (ret) : "r" (ptr));
     return ret;
 }
-extern __inline__ unsigned long GETLE32(unsigned long *ptr) {
+static __inline__ unsigned long GETLE32(unsigned long *ptr) {
     unsigned long ret;
     __asm__ ("lwbrx %0, 0, %1" : "=r" (ret) : "r" (ptr));
     return ret;
 }
-extern __inline__ unsigned long GETLE16D(unsigned long *ptr) {
+static __inline__ unsigned long GETLE16D(unsigned long *ptr) {
     unsigned long ret;
     __asm__ ("lwbrx %0, 0, %1\n"
              "rlwinm %0, %0, 16, 0, 31" : "=r" (ret) : "r" (ptr));
     return ret;
 }
 
-extern __inline__ void PUTLE16(unsigned short *ptr, unsigned short val) {
+static __inline__ void PUTLE16(unsigned short *ptr, unsigned short val) {
     __asm__ ("sthbrx %0, 0, %1" : : "r" (val), "r" (ptr) : "memory");
 }
-extern __inline__ void PUTLE32(unsigned long *ptr, unsigned long val) {
+static __inline__ void PUTLE32(unsigned long *ptr, unsigned long val) {
     __asm__ ("stwbrx %0, 0, %1" : : "r" (val), "r" (ptr) : "memory");
 }
 #else // _BIG_ENDIAN

--- a/cdrom.c
+++ b/cdrom.c
@@ -64,6 +64,8 @@
 #define ASYNC		254
 /* don't set 255, it's reserved */
 
+cdrStruct cdr;
+
 char *CmdName[0x100]= {
     "CdlSync",     "CdlNop",       "CdlSetloc",  "CdlPlay",
     "CdlForward",  "CdlBackward",  "CdlReadN",   "CdlStandby",

--- a/cdrom.h
+++ b/cdrom.h
@@ -77,7 +77,7 @@ typedef struct {
 	char Unused[4083];
 } cdrStruct;
 
-cdrStruct cdr;
+extern cdrStruct cdr;
 
 void cdrReset();
 void cdrInterrupt();

--- a/misc.c
+++ b/misc.c
@@ -29,6 +29,8 @@
 #include "Gamecube/fileBrowser/fileBrowser-libfat.h"
 
 int Log = 0;
+char CdromId[10];
+char CdromLabel[33];
 
 /* PSX Executable types */
 #define PSX_EXE     1

--- a/misc.h
+++ b/misc.h
@@ -50,8 +50,8 @@ typedef struct {
     u32 SavedS0;
 } EXE_HEADER;
 
-char CdromId[10];
-char CdromLabel[33];
+extern char CdromId[10];
+extern char CdromLabel[33];
 
 int LoadCdrom();
 int LoadCdromFile(char *filename, EXE_HEADER *head);

--- a/plugins.h
+++ b/plugins.h
@@ -80,28 +80,28 @@ typedef void (CALLBACK* GPUclearDynarec)(void (CALLBACK *callback)(void));
 //plugin stuff From Shadow
 // *** walking in the valley of your darking soul i realize that i was alone
 //Gpu function pointers
-GPUupdateLace    GPU_updateLace;
-GPUinit          GPU_init;
-GPUshutdown      GPU_shutdown; 
-GPUconfigure     GPU_configure;
-GPUtest          GPU_test;
-GPUabout         GPU_about;
-GPUopen          GPU_open;
-GPUclose         GPU_close;
-GPUreadStatus    GPU_readStatus;
-GPUreadData      GPU_readData;
-GPUreadDataMem   GPU_readDataMem;
-GPUwriteStatus   GPU_writeStatus; 
-GPUwriteData     GPU_writeData;
-GPUwriteDataMem  GPU_writeDataMem;
-GPUdmaChain      GPU_dmaChain;
-GPUkeypressed    GPU_keypressed;
-GPUdisplayText   GPU_displayText;
-GPUmakeSnapshot  GPU_makeSnapshot;
-GPUfreeze        GPU_freeze;
-GPUgetScreenPic  GPU_getScreenPic;
-GPUshowScreenPic GPU_showScreenPic;
-GPUclearDynarec  GPU_clearDynarec;
+extern GPUupdateLace    GPU_updateLace;
+extern GPUinit          GPU_init;
+extern GPUshutdown      GPU_shutdown;
+extern GPUconfigure     GPU_configure;
+extern GPUtest          GPU_test;
+extern GPUabout         GPU_about;
+extern GPUopen          GPU_open;
+extern GPUclose         GPU_close;
+extern GPUreadStatus    GPU_readStatus;
+extern GPUreadData      GPU_readData;
+extern GPUreadDataMem   GPU_readDataMem;
+extern GPUwriteStatus   GPU_writeStatus;
+extern GPUwriteData     GPU_writeData;
+extern GPUwriteDataMem  GPU_writeDataMem;
+extern GPUdmaChain      GPU_dmaChain;
+extern GPUkeypressed    GPU_keypressed;
+extern GPUdisplayText   GPU_displayText;
+extern GPUmakeSnapshot  GPU_makeSnapshot;
+extern GPUfreeze        GPU_freeze;
+extern GPUgetScreenPic  GPU_getScreenPic;
+extern GPUshowScreenPic GPU_showScreenPic;
+extern GPUclearDynarec  GPU_clearDynarec;
 
 //cd rom plugin ;)
 typedef long (CALLBACK* CDRinit)(void);
@@ -138,23 +138,23 @@ struct SubQ {
 typedef unsigned char* (CALLBACK* CDRgetBufferSub)(void);
 
 //cd rom function pointers 
-CDRinit               CDR_init;
-CDRshutdown           CDR_shutdown;
-CDRopen               CDR_open;
-CDRclose              CDR_close; 
-CDRtest               CDR_test;
-CDRgetTN              CDR_getTN;
-CDRgetTD              CDR_getTD;
-CDRreadTrack          CDR_readTrack;
-CDRgetBuffer          CDR_getBuffer;
-CDRplay               CDR_play;
-CDRstop               CDR_stop;
-CDRgetStatus          CDR_getStatus;
-CDRgetDriveLetter     CDR_getDriveLetter;
-CDRgetBufferSub       CDR_getBufferSub;
-CDRconfigure          CDR_configure;
-CDRabout              CDR_about;
-CDRsetfilename        CDR_setfilename;
+extern CDRinit               CDR_init;
+extern CDRshutdown           CDR_shutdown;
+extern CDRopen               CDR_open;
+extern CDRclose              CDR_close;
+extern CDRtest               CDR_test;
+extern CDRgetTN              CDR_getTN;
+extern CDRgetTD              CDR_getTD;
+extern CDRreadTrack          CDR_readTrack;
+extern CDRgetBuffer          CDR_getBuffer;
+extern CDRplay               CDR_play;
+extern CDRstop               CDR_stop;
+extern CDRgetStatus          CDR_getStatus;
+extern CDRgetDriveLetter     CDR_getDriveLetter;
+extern CDRgetBufferSub       CDR_getBufferSub;
+extern CDRconfigure          CDR_configure;
+extern CDRabout              CDR_about;
+extern CDRsetfilename        CDR_setfilename;
 
 // spu plugin
 typedef long (CALLBACK* SPUinit)(void);				
@@ -197,35 +197,35 @@ typedef long (CALLBACK* SPUfreeze)(uint32_t, SPUFreeze_t *);
 typedef void (CALLBACK* SPUasync)(uint32_t);
 
 //SPU POINTERS
-SPUconfigure        SPU_configure;
-SPUabout            SPU_about;
-SPUinit             SPU_init;
-SPUshutdown         SPU_shutdown;
-SPUtest             SPU_test;
-SPUopen             SPU_open;
-SPUclose            SPU_close;
-SPUplaySample       SPU_playSample;
-SPUstartChannels1   SPU_startChannels1;
-SPUstartChannels2   SPU_startChannels2;
-SPUstopChannels1    SPU_stopChannels1;
-SPUstopChannels2    SPU_stopChannels2;
-SPUputOne           SPU_putOne;
-SPUgetOne           SPU_getOne;
-SPUsetAddr          SPU_setAddr;
-SPUsetPitch         SPU_setPitch;
-SPUsetVolumeL       SPU_setVolumeL;
-SPUsetVolumeR       SPU_setVolumeR;
-SPUwriteRegister    SPU_writeRegister;
-SPUreadRegister     SPU_readRegister;
-SPUwriteDMA         SPU_writeDMA;
-SPUreadDMA          SPU_readDMA;
-SPUwriteDMAMem      SPU_writeDMAMem;
-SPUreadDMAMem       SPU_readDMAMem;
-SPUplayADPCMchannel SPU_playADPCMchannel;
-SPUfreeze           SPU_freeze;
-SPUregisterCallback SPU_registerCallback;
-SPUregisterCDDAVolume SPU_registerCDDAVolume;
-SPUasync            SPU_async;
+extern SPUconfigure        SPU_configure;
+extern SPUabout            SPU_about;
+extern SPUinit             SPU_init;
+extern SPUshutdown         SPU_shutdown;
+extern SPUtest             SPU_test;
+extern SPUopen             SPU_open;
+extern SPUclose            SPU_close;
+extern SPUplaySample       SPU_playSample;
+extern SPUstartChannels1   SPU_startChannels1;
+extern SPUstartChannels2   SPU_startChannels2;
+extern SPUstopChannels1    SPU_stopChannels1;
+extern SPUstopChannels2    SPU_stopChannels2;
+extern SPUputOne           SPU_putOne;
+extern SPUgetOne           SPU_getOne;
+extern SPUsetAddr          SPU_setAddr;
+extern SPUsetPitch         SPU_setPitch;
+extern SPUsetVolumeL       SPU_setVolumeL;
+extern SPUsetVolumeR       SPU_setVolumeR;
+extern SPUwriteRegister    SPU_writeRegister;
+extern SPUreadRegister     SPU_readRegister;
+extern SPUwriteDMA         SPU_writeDMA;
+extern SPUreadDMA          SPU_readDMA;
+extern SPUwriteDMAMem      SPU_writeDMAMem;
+extern SPUreadDMAMem       SPU_readDMAMem;
+extern SPUplayADPCMchannel SPU_playADPCMchannel;
+extern SPUfreeze           SPU_freeze;
+extern SPUregisterCallback SPU_registerCallback;
+extern SPUregisterCDDAVolume SPU_registerCDDAVolume;
+extern SPUasync            SPU_async;
 
 // PAD Functions
 
@@ -244,33 +244,33 @@ typedef unsigned char (CALLBACK* PADpoll)(unsigned char);
 typedef void (CALLBACK* PADsetSensitive)(int);
 
 //PAD POINTERS
-PADconfigure        PAD1_configure;
-PADabout            PAD1_about;
-PADinit             PAD1_init;
-PADshutdown         PAD1_shutdown;
-PADtest             PAD1_test;
-PADopen             PAD1_open;
-PADclose            PAD1_close;
-PADquery			PAD1_query;
-PADreadPort1		PAD1_readPort1;
-PADkeypressed		PAD1_keypressed;
-PADstartPoll        PAD1_startPoll;
-PADpoll             PAD1_poll;
-PADsetSensitive     PAD1_setSensitive;
+extern PADconfigure        PAD1_configure;
+extern PADabout            PAD1_about;
+extern PADinit             PAD1_init;
+extern PADshutdown         PAD1_shutdown;
+extern PADtest             PAD1_test;
+extern PADopen             PAD1_open;
+extern PADclose            PAD1_close;
+extern PADquery			PAD1_query;
+extern PADreadPort1		PAD1_readPort1;
+extern PADkeypressed		PAD1_keypressed;
+extern PADstartPoll        PAD1_startPoll;
+extern PADpoll             PAD1_poll;
+extern PADsetSensitive     PAD1_setSensitive;
 
-PADconfigure        PAD2_configure;
-PADabout            PAD2_about;
-PADinit             PAD2_init;
-PADshutdown         PAD2_shutdown;
-PADtest             PAD2_test;
-PADopen             PAD2_open;
-PADclose            PAD2_close;
-PADquery            PAD2_query;
-PADreadPort2		PAD2_readPort2;
-PADkeypressed		PAD2_keypressed;
-PADstartPoll        PAD2_startPoll;
-PADpoll             PAD2_poll;
-PADsetSensitive     PAD2_setSensitive;
+extern PADconfigure        PAD2_configure;
+extern PADabout            PAD2_about;
+extern PADinit             PAD2_init;
+extern PADshutdown         PAD2_shutdown;
+extern PADtest             PAD2_test;
+extern PADopen             PAD2_open;
+extern PADclose            PAD2_close;
+extern PADquery            PAD2_query;
+extern PADreadPort2		PAD2_readPort2;
+extern PADkeypressed		PAD2_keypressed;
+extern PADstartPoll        PAD2_startPoll;
+extern PADpoll             PAD2_poll;
+extern PADsetSensitive     PAD2_setSensitive;
 
 // NET plugin
 
@@ -311,22 +311,22 @@ typedef long (CALLBACK* NETkeypressed)(int)
 
 
 // NET function pointers 
-NETinit               NET_init;
-NETshutdown           NET_shutdown;
-NETopen               NET_open;
-NETclose              NET_close; 
-NETtest               NET_test;
-NETconfigure          NET_configure;
-NETabout              NET_about;
-NETpause              NET_pause;
-NETresume             NET_resume;
-NETqueryPlayer        NET_queryPlayer;
-NETsendData           NET_sendData;
-NETrecvData           NET_recvData;
-NETsendPadData        NET_sendPadData;
-NETrecvPadData        NET_recvPadData;
-NETsetInfo            NET_setInfo;
-NETkeypressed         NET_keypressed;
+extern NETinit               NET_init;
+extern NETshutdown           NET_shutdown;
+extern NETopen               NET_open;
+extern NETclose              NET_close;
+extern NETtest               NET_test;
+extern NETconfigure          NET_configure;
+extern NETabout              NET_about;
+extern NETpause              NET_pause;
+extern NETresume             NET_resume;
+extern NETqueryPlayer        NET_queryPlayer;
+extern NETsendData           NET_sendData;
+extern NETrecvData           NET_recvData;
+extern NETsendPadData        NET_sendPadData;
+extern NETrecvPadData        NET_recvPadData;
+extern NETsetInfo            NET_setInfo;
+extern NETkeypressed         NET_keypressed;
 
 int LoadCDRplugin(char *CDRdll);
 int LoadGPUplugin(char *GPUdll);

--- a/psxcounters.c
+++ b/psxcounters.c
@@ -26,6 +26,7 @@
 
 static int cnts = 4;
 psxCounter psxCounters[5];
+u32 psxNextCounter, psxNextsCounter;
 
 static void psxRcntUpd(unsigned long index) {
 	psxCounters[index].sCycle = psxRegs.cycle;

--- a/psxcounters.h
+++ b/psxcounters.h
@@ -32,7 +32,7 @@ typedef struct {
 
 extern psxCounter psxCounters[5];
 
-u32 psxNextCounter, psxNextsCounter;
+extern u32 psxNextCounter, psxNextsCounter;
 
 void psxRcntInit();
 void psxRcntUpdate();

--- a/psxmem.c
+++ b/psxmem.c
@@ -54,6 +54,8 @@
 
 extern void SysMessage(char *fmt, ...);
 
+s8 *psxP;
+s8 *psxH;
 s8 psxM[0x00220000] __attribute__((aligned(32)));
 s8 psxR[0x00080000] __attribute__((aligned(32)));
 u8* psxMemWLUT[0x10000] __attribute__((aligned(32)));

--- a/psxmem.h
+++ b/psxmem.h
@@ -64,7 +64,7 @@ extern s8 psxM[0x00220000] __attribute__((aligned(32)));
 #define psxMu16ref(mem)	(*(u16*)&psxM[(mem) & 0x1fffff])
 #define psxMu32ref(mem)	(*(u32*)&psxM[(mem) & 0x1fffff])
 
-s8 *psxP;
+extern s8 *psxP;
 #define psxPs8(mem)	    psxP[(mem) & 0xffff]
 #define psxPs16(mem)	(SWAP16(*(s16*)&psxP[(mem) & 0xffff]))
 #define psxPs32(mem)	(SWAP32(*(s32*)&psxP[(mem) & 0xffff]))
@@ -94,7 +94,7 @@ extern s8 psxR[0x00080000] __attribute__((aligned(32)));
 #define psxRu16ref(mem)	(*(u16*)&psxR[(mem) & 0x7ffff])
 #define psxRu32ref(mem)	(*(u32*)&psxR[(mem) & 0x7ffff])
 
-s8 *psxH;
+extern s8 *psxH;
 #define psxHs8(mem)		psxH[(mem) & 0xffff]
 #define psxHs16(mem)	(SWAP16(*(s16*)&psxH[(mem) & 0xffff]))
 #define psxHs32(mem)	(SWAP32(*(s32*)&psxH[(mem) & 0xffff]))


### PR DESCRIPTION
With devkitPPC release 38 - 10.2.0 (versions for powerpc-eabi-gcc and powerpc-eabi-g++) i can't compile (link) the current master version of WiiSXRX. The linker produce many 'multiple definition of ...' messages and failed to link successfully.

The main reason are the global (non static) variables in header files and the extern inline functions in the header files. Including this header files in different translation units produces the multiple definitions. To fix it I make the definition of the non-static global variables in the correct c-files and only give the declarations to the header file (with extern). The inline functions are changed from extern inline to static inline to avoid the multiple definitions.