### PR TITLE
Fixed assigning no controller (based on Extrems' fix on Not64 code)

### DIFF
--- a/Gamecube/menu/ConfigureInputFrame.cpp
+++ b/Gamecube/menu/ConfigureInputFrame.cpp
@@ -238,9 +238,9 @@ void Func_TogglePad0Type()
 {
 	int i = PADASSIGN_INPUT0;
 #ifdef HW_RVL
-	padType[i] = (padType[i]+1) %3;
+	padType[i] = (padType[i]==PADTYPE_WII) ? PADTYPE_NONE : padType[i]+1;
 #else
-	padType[i] = (padType[i]+1) %2;
+	padType[i] = (padType[i]==PADTYPE_GAMECUBE) ? PADTYPE_NONE : padType[i]+1;
 #endif
 
 	if (padType[i]) Func_AssignPad(i);
@@ -252,9 +252,9 @@ void Func_TogglePad1Type()
 {
 	int i = PADASSIGN_INPUT1;
 #ifdef HW_RVL
-	padType[i] = (padType[i]+1) %3;
+	padType[i] = (padType[i]==PADTYPE_WII) ? PADTYPE_NONE : padType[i]+1;
 #else
-	padType[i] = (padType[i]+1) %2;
+	padType[i] = (padType[i]==PADTYPE_GAMECUBE) ? PADTYPE_NONE : padType[i]+1;
 #endif
 
 	if (padType[i]) Func_AssignPad(i);


### PR DESCRIPTION
Hi there @niuus, i want to implement this small code for fix a issue with controller detection on WiiSX RX.

Fixed assigning no controller when WiiSX RX boots up, based in this fix on Not64 emulator by @Extrems (https://github.com/extremscorner/not64/commit/1cfbaa363e356d8c4ec93aa7fe2b9f2024f01505).

Hope this will be added to WiiSXRX in a new version soon.

@saulfabregwiivc