### PR TITLE
Fix some issues on GUI on WiiSXRX-Evo branch (xjsxjs197)

### DIFF
--- a/Gamecube/menu/MainFrame.cpp
+++ b/Gamecube/menu/MainFrame.cpp
@@ -212,7 +212,10 @@ void Func_ExitToLoader()
 	if (menu::MessageBox::getInstance().askMessage("Are you sure you want to exit to loader?"))
     {
         shutdown = 2;
-        SysClose();
+        if (hasLoadedISO)
+        {
+            SysClose();
+        }
     }
 }
 

--- a/cdriso.c
+++ b/cdriso.c
@@ -1583,8 +1583,8 @@ static long CALLBACK ISOopen(void) {
 		return 0; // it's already open
 	}
 
-	if (isoFile_open(GetIsoFile()) == FILE_BROWSER_ERROR_NO_FILE) {
-        return -1;
+	if (strlen(GetIsoFile()) == 0 || isoFile_open(GetIsoFile()) == FILE_BROWSER_ERROR_NO_FILE) {
+        return 0;
     }
 
 	cdHandle = fopen(GetIsoFile(), "rb");


### PR DESCRIPTION
These code changes fixes these issues:

- If you load the emulator, then press "Quit" and then "OK" without loading a game, it causes an instant ISI (not DSI) error.
- If you load the emulator, then press "Settings", and then "Execute Bios", it causes an instant ISI error.

Taken from xjsxjs197's fix https://github.com/xjsxjs197/WiiSXRX_2022/commit/7669390beef92c0396aff3c32f579512e8629ec4