### PR TITLE
SIO wait time update on Evo branch (fixes controls on some games) (xjsxjs197)

### DIFF
--- a/sio.c
+++ b/sio.c
@@ -57,12 +57,14 @@ char *Mcd2Data = (char*)MCD2_LO;
 char Mcd1Data[MCD_SIZE], Mcd2Data[MCD_SIZE];
 #endif
 
+#define SIO_CYCLES		535
+
 // clk cycle byte
 // 4us * 8bits = ((PSXCLK / 1000000) * 32) / BIAS; (linuzappz)
 #define SIO_INT() { \
 	if (!Config.Sio) { \
 		psxRegs.interrupt |= (1 << PSXINT_SIO); \
-		psxRegs.intCycle[PSXINT_SIO].cycle = 200; \
+		psxRegs.intCycle[PSXINT_SIO].cycle = SIO_CYCLES; \
 		psxRegs.intCycle[PSXINT_SIO].sCycle = psxRegs.cycle; \
 	} \
 }


### PR DESCRIPTION
Updated the value on SIO cycles.
Makes some games to have control input on WiiSX-RX.

Games tested with this fix:
- Road & Track Presents - The Need for Speed
- Blast Chamber

Fix taken from @xjsxjs197's repo in this commit: https://github.com/xjsxjs197/WiiSXRX_2022/commit/a12c773fb8471536c3992ce7c637d9c7e13009d3