### PR TITLE
Increase the length of the path buffer to WiiSXRX-Evo (xjsxjs197)

### DIFF
--- a/Gamecube/fileBrowser/fileBrowser.h
+++ b/Gamecube/fileBrowser/fileBrowser.h
@@ -27,7 +27,7 @@
 
 #include <stdint.h>
 
-#define FILE_BROWSER_MAX_PATH_LEN 128
+#define FILE_BROWSER_MAX_PATH_LEN 256
 
 #define FILE_BROWSER_ATTR_DIR     0x10
 


### PR DESCRIPTION
From commit https://github.com/xjsxjs197/WiiSXRX_2022/commit/04403f5e1e6ac2fa4516b88feae0831cea1da5f8

Fixes issues:
- Have a folder called "Lost World, The - Jurassic Park - Special Edition (USA)" inside the isos folder. If the game file inside exceeds 52 characters, it will say "Failed to load ISO". Under the same circumstances, open the folder, but don't load the game. Press ".." once, and enter the folder again. Instant DSI crash.
- Have a folder called "2022" inside the isos folder. Inside the "2022" folder, create another folder called "Dragon Ball Z - Idainaru Dragon Ball Densetsu (Japan)". Have the bin+cue inside, called the same as the folder. Whichever you load, it will say "Failed to load ISO".
Under the same circumstances, open the folder, but don't load the game. Press ".." once, and enter the folder again. Instant DSI crash.
- Have a folder called "2022" inside the isos folder. Inside the "2022" folder, create another folder called "Dragon Ball Z - Idainaru Dragon Ball Densetsu (Japan)". Have the bin called "Dragon Ball Z - Idainaru Dragon Ball Densetsu (" and the cue called "Dragon Ball Z - Idainaru Dragon Ball Densetsu (Japan)" inside. Press ".." once, and enter the folder again. The filename will display 3 characters only. If you press "..." again, filenames will disappear. Press B to go back to normal. In this example, you can load the bin but only if it doesn't exceed 47 characters.