### PR TITLE
Fix system timing autoFix function (xjsxjs197)

### DIFF
--- a/psxcounters.c
+++ b/psxcounters.c
@@ -509,7 +509,8 @@ u32 psxRcntRcount( u32 index )
         {
             if( rcnts[index].counterState == CountToTarget )
             {
-                count /= BIAS;
+                //count /= BIAS;
+                count = count >> 1;
             }
         }
     }


### PR DESCRIPTION
This fixes the system timing autoFix function, allowing the games Vandal Hearts, Parasite Eve II, etc., to work again on WiiSXRX.

Tested and working as a charm on latest code for WiiSXRX 3.2.

Taken from https://github.com/xjsxjs197/WiiSXRX_2022/commit/d5df2fbc2f2799b351862ae496c26e29a1e66da0