### PR TITLE
improve autoFix functions, add more autoFixes, fix timing autoFix, allow to use autoFixes on autoboot mode (xjsxjs197)

### DIFF
--- a/Gamecube/menu/FileBrowserFrame.cpp
+++ b/Gamecube/menu/FileBrowserFrame.cpp
@@ -480,6 +480,8 @@ int ChkString(char * str1, char * str2, int len)
 
 // hack for emulating "gpu busy" in some games
 extern unsigned long dwEmuFixes;
+// For special game correction
+extern unsigned long dwActFixes;
 
 static void CheckGameAutoFix(void){
 	Config.RCntFix = 0;
@@ -519,9 +521,7 @@ static void CheckGameAutoFix(void){
 	|| ChkString(CdromId, "SLPS02780", strlen("SLPS02780"))){ // PARASITE EVE II [SQUARESOFT MILLENNIUM COLLECTION] - [ 2 DISCS ]
 		Config.RCntFix = 1;
 	}
-}
 
-static void CheckGameGPUBusyAutoFix(void){
 	dwEmuFixes = 0;
 	if (ChkString(CdromId, "SLUS00964", strlen("SLUS00964")) // Hot Wheels - Turbo Racing [NTSC-U]
 	|| ChkString(CdromId, "SLES02198", strlen("SLES02198")) // Hot Wheels - Turbo Racing [PAL]
@@ -541,6 +541,15 @@ static void CheckGameGPUBusyAutoFix(void){
 	|| ChkString(CdromId, "SLUS00859", strlen("SLUS00859")) // The Dukes of Hazzard: Racing for Home [NTSC-U]
 	|| ChkString(CdromId, "SLES02343", strlen("SLES02343"))){ // The Dukes of Hazzard: Racing for Home [PAL]
 		dwEmuFixes = 0x0001;
+	}
+
+	dwActFixes = 0;
+	if (ChkString(CdromId, "SLUS00297", strlen("SLUS00297")) // Star Wars - Dark Forces [NTSC-U]
+	|| ChkString(CdromId, "SLPS00685", strlen("SLPS00685")) // Star Wars - Dark Forces [NTSC-J]
+	|| ChkString(CdromId, "SLES00585", strlen("SLES00585")) // Star Wars - Dark Forces [PAL]
+	|| ChkString(CdromId, "SLES00640", strlen("SLES00640")) // Star Wars - Dark Forces [Italy]
+	|| ChkString(CdromId, "SLPS00646", strlen("SLPS00646"))){ // Star Wars - Dark Forces [Spain]
+		dwActFixes |= 0x100;
 	}
 }
 
@@ -587,8 +596,7 @@ void fileBrowserFrame_LoadFile(int i)
 			if(Autoboot){
 				// saulfabreg: autoFix functions work fine but not in autoboot mode...
 				// let's fix this :)
-				CheckGameAutoFix(); // for system timing autoFix (Vandal Hearts, Parasite Eve II, etc.)
-				CheckGameGPUBusyAutoFix(); // for GPU 'Fake Busy States' autoFix (Hot Wheels Turbo Racing, etc.)
+				CheckGameAutoFix(); // for per-game autoFix (Vandal Hearts, Parasite Eve II, Hot Wheels Turbo Racing, etc.)
 				CheckGameR3000AutoFix(); // for pR3000A autoFix (EA Sports Supercross 2000, etc.)
 
 				// FIXME: The MessageBox is a hacky way to fix input not responding.
@@ -618,11 +626,15 @@ void fileBrowserFrame_LoadFile(int i)
             		{
                 		sprintf(buffer, "RCnt2 auto fixed\n");
             		}
-			CheckGameGPUBusyAutoFix();
             		if (dwEmuFixes)
             		{
                 		sprintf(buffer, "GPU 'Fake Busy States' hacked\n");
             		}
+			if (dwActFixes)
+			{
+				sprintf(buffer, "Special game auto fixed\n");
+				strcat(RomInfo,buffer);
+			}
 			// auto recJR => psxJR for some game
 			CheckGameR3000AutoFix();
 			if (Config.pR3000Fix)

--- a/Gamecube/menu/FileBrowserFrame.cpp
+++ b/Gamecube/menu/FileBrowserFrame.cpp
@@ -587,6 +587,9 @@ void fileBrowserFrame_LoadFile(int i)
 			if(Autoboot){
 				// saulfabreg: autoFix functions work fine but not in autoboot mode...
 				// let's fix this :)
+				CheckGameAutoFix(); // for system timing autoFix (Vandal Hearts, Parasite Eve II, etc.)
+				CheckGameGPUBusyAutoFix(); // for GPU 'Fake Busy States' autoFix (Hot Wheels Turbo Racing, etc.)
+				CheckGameR3000AutoFix(); // for pR3000A autoFix (EA Sports Supercross 2000, etc.)
 
 				// FIXME: The MessageBox is a hacky way to fix input not responding.
 				// No time to improve this...

--- a/Gamecube/menu/FileBrowserFrame.cpp
+++ b/Gamecube/menu/FileBrowserFrame.cpp
@@ -478,6 +478,96 @@ int ChkString(char * str1, char * str2, int len)
 }
 // add xjsxjs197 end
 
+// hack for emulating "gpu busy" in some games
+extern unsigned long dwEmuFixes;
+
+static void CheckGameAutoFix(void){
+	Config.RCntFix = 0;
+	if (ChkString(CdromId, "SLUS00447", strlen("SLUS00447")) // VANDAL HEARTS
+	|| ChkString(CdromId, "SLUS00940", strlen("SLUS00940")) // VANDAL HEARTS II
+	|| ChkString(CdromId, "SLUS01042", strlen("SLUS01042")) // PARASITE EVE II (disk1)
+	|| ChkString(CdromId, "SLUS01055", strlen("SLUS01055")) // PARASITE EVE II (disk2 ?)
+	|| ChkString(CdromId, "SLES00204", strlen("SLES00204")) // VANDAL HEARTS
+	|| ChkString(CdromId, "SLES02469", strlen("SLES02469")) // VANDAL HEARTS II
+	|| ChkString(CdromId, "SLES02496", strlen("SLES02496")) // VANDAL HEARTS II
+	|| ChkString(CdromId, "SLES02497", strlen("SLES02497")) // VANDAL HEARTS II
+	|| ChkString(CdromId, "SLES02558", strlen("SLES02558")) // PARASITE EVE 2 (disk1)
+	|| ChkString(CdromId, "SLES12558", strlen("SLES12558")) // PARASITE EVE 2 (disk2 ?)
+	|| ChkString(CdromId, "SLES02559", strlen("SLES02559")) // PARASITE EVE 2 (disk1)
+	|| ChkString(CdromId, "SLES12559", strlen("SLES12559")) // PARASITE EVE 2 (disk2 ?)
+	|| ChkString(CdromId, "SLES02560", strlen("SLES02560")) // PARASITE EVE 2 (disk1)
+	|| ChkString(CdromId, "SLES12560", strlen("SLES12560")) // PARASITE EVE 2 (disk2 ?)
+	|| ChkString(CdromId, "SLES02561", strlen("SLES02561")) // PARASITE EVE 2 (disk1)
+	|| ChkString(CdromId, "SLES12561", strlen("SLES12561")) // PARASITE EVE 2 (disk2 ?)
+	|| ChkString(CdromId, "SLES02562", strlen("SLES02562")) // PARASITE EVE 2 (disk1)
+	|| ChkString(CdromId, "SLES12562", strlen("SLES12562")) // PARASITE EVE 2 (disk2 ?)
+	|| ChkString(CdromId, "SCPS45183", strlen("SCPS45183")) // VANDAL HEARTS - USHINAWARETA KODAI BUNMEI
+	|| ChkString(CdromId, "SLPM86007", strlen("SLPM86007")) // VANDAL HEARTS - USHINAWARETA KODAI BUNMEI
+	|| ChkString(CdromId, "SLPM86067", strlen("SLPM86067")) // VANDAL HEARTS - USHINAWARETA KODAI BUNMEI [PLAYSTATION THE BEST]
+	|| ChkString(CdromId, "SLPM87278", strlen("SLPM87278")) // VANDAL HEARTS - USHINAWARETA KODAI BUNMEI [PSONE BOOKS]
+	|| ChkString(CdromId, "SCPS45415", strlen("SCPS45415")) // VANDAL HEARTS II - TENJOU NO MON
+	|| ChkString(CdromId, "SLPM86251", strlen("SLPM86251")) // VANDAL HEARTS II - TENJOU NO MON
+	|| ChkString(CdromId, "SLPM86504", strlen("SLPM86504")) // VANDAL HEARTS II - TENJOU NO MON [KONAMI THE BEST]
+	|| ChkString(CdromId, "SLPM87279", strlen("SLPM87279")) // VANDAL HEARTS II - TENJOU NO MON [PSONE BOOKS]
+	|| ChkString(CdromId, "SCPS45467", strlen("SCPS45467")) // PARASITE EVE II [ 2 DISCS ]
+	|| ChkString(CdromId, "SCPS45468", strlen("SCPS45468")) // PARASITE EVE II [ 2 DISCS ]
+	|| ChkString(CdromId, "SLPS02480", strlen("SLPS02480")) // PARASITE EVE II [ 2 DISCS ]
+	|| ChkString(CdromId, "SLPS02481", strlen("SLPS02481")) // PARASITE EVE II [ 2 DISCS ]
+	|| ChkString(CdromId, "SLPS91479", strlen("SLPS91479")) // PARASITE EVE II [PSONE BOOKS] [ 2 DISCS ]
+	|| ChkString(CdromId, "SLPS91480", strlen("SLPS91480")) // PARASITE EVE II [PSONE BOOKS] [ 2 DISCS ]
+	|| ChkString(CdromId, "SLPS02779", strlen("SLPS02779")) // PARASITE EVE II [SQUARESOFT MILLENNIUM COLLECTION] - [ 2 DISCS ]
+	|| ChkString(CdromId, "SLPS02780", strlen("SLPS02780"))){ // PARASITE EVE II [SQUARESOFT MILLENNIUM COLLECTION] - [ 2 DISCS ]
+		Config.RCntFix = 1;
+	}
+}
+
+static void CheckGameGPUBusyAutoFix(void){
+	dwEmuFixes = 0;
+	if (ChkString(CdromId, "SLUS00964", strlen("SLUS00964")) // Hot Wheels - Turbo Racing [NTSC-U]
+	|| ChkString(CdromId, "SLES02198", strlen("SLES02198")) // Hot Wheels - Turbo Racing [PAL]
+	|| ChkString(CdromId, "SLPS01919", strlen("SLPS01919")) // To Heart [NTSC-J - Disk 1]
+	|| ChkString(CdromId, "SLPS01920", strlen("SLPS01920")) // To Heart [NTSC-J - Disk 2]
+	|| ChkString(CdromId, "SLPS01383", strlen("SLPS01383")) // FIFA - Road to World Cup '98 [NTSC-J]
+	|| ChkString(CdromId, "SLPS91150", strlen("SLPS91150")) // FIFA - Road to World Cup '98 [NTSC-J - PlayStation The Best]
+	|| ChkString(CdromId, "SLUS00520", strlen("SLUS00520")) // FIFA - Road to World Cup '98 [NTSC-U]
+	|| ChkString(CdromId, "SLES00914", strlen("SLES00914")) // FIFA - Road to World Cup '98 [PAL]
+	|| ChkString(CdromId, "SLES00915", strlen("SLES00915")) // FIFA - Road to World Cup '98 [France]
+	|| ChkString(CdromId, "SLES00916", strlen("SLES00916")) // FIFA - Road to World Cup '98 [Germany]
+	|| ChkString(CdromId, "SLES00917", strlen("SLES00917")) // FIFA - Road to World Cup '98 [Italy]
+	|| ChkString(CdromId, "SLES00918", strlen("SLES00918")) // FIFA - Road to World Cup '98 [Spain]
+	|| ChkString(CdromId, "SLPS01158", strlen("SLPS01158")) // Ishin no Arashi [NTSC-J]
+	|| ChkString(CdromId, "SLPM86861", strlen("SLPM86861")) // Ishin no Arashi [NTSC-J - Koei Teiban Series]
+	|| ChkString(CdromId, "SLPM86235", strlen("SLPM86235")) // Ishin no Arashi [NTSC-J - Koei The Best]
+	|| ChkString(CdromId, "SLUS00859", strlen("SLUS00859")) // The Dukes of Hazzard: Racing for Home [NTSC-U]
+	|| ChkString(CdromId, "SLES02343", strlen("SLES02343"))){ // The Dukes of Hazzard: Racing for Home [PAL]
+		dwEmuFixes = 0x0001;
+	}
+}
+
+static void CheckGameR3000AutoFix(void){
+	Config.pR3000Fix = 0;
+	if (ChkString(CdromId, "SLES00037", strlen("SLES00037")) // Alone in the Dark - Jack is Back
+	|| ChkString(CdromId, "SLPS00141", strlen("SLPS00141"))
+	|| ChkString(CdromId, "SLUS00239", strlen("SLUS00239"))
+	|| ChkString(CdromId, "SLUS00590", strlen("SLUS00590")) // Need for Speed - V-Rally
+	|| ChkString(CdromId, "SLES00250", strlen("SLES00250"))
+	|| ChkString(CdromId, "SLPS01149", strlen("SLPS01149"))
+	|| ChkString(CdromId, "SLPS91099", strlen("SLPS91099"))
+	|| ChkString(CdromId, "SLPS91430", strlen("SLPS91430"))){
+		Config.pR3000Fix = 1;
+        }
+
+	if (ChkString(CdromId, "SLUS01005", strlen("SLUS01005")) // EA Sports Supercross 2000
+	|| ChkString(CdromId, "SLES02373", strlen("SLES02373"))){
+		Config.pR3000Fix = 2;
+        }
+
+	if (ChkString(CdromId, "SLUS00964", strlen("SLUS00964")) // Hot Wheels - Turbo Racing
+	|| ChkString(CdromId, "SLES02198", strlen("SLES02198"))){
+		Config.pR3000Fix = 3;
+	}
+}
+
 void fileBrowserFrame_LoadFile(int i)
 {
 	char feedback_string[256] = "Failed to load ISO";
@@ -495,6 +585,9 @@ void fileBrowserFrame_LoadFile(int i)
 
 		if(!ret){	// If the read succeeded.
 			if(Autoboot){
+				// saulfabreg: autoFix functions work fine but not in autoboot mode...
+				// let's fix this :)
+
 				// FIXME: The MessageBox is a hacky way to fix input not responding.
 				// No time to improve this...
 				menu::MessageBox::getInstance().setMessage("Autobooting game...");
@@ -513,31 +606,27 @@ void fileBrowserFrame_LoadFile(int i)
 			strcat(RomInfo,feedback_string);
 			sprintf(buffer,"\nCD-ROM Label: %s\n",CdromLabel);
 			strcat(RomInfo,buffer);
-			// add xjsxjs197 start
-			Config.RCntFix = 0;
-			if (ChkString(CdromLabel, "SLUS01042", strlen("SLUS01042")) // PARASITE EVE 2(CD1)
-				|| ChkString(CdromLabel, "SLUS01055", strlen("SLUS01055")) // PARASITE EVE 2(CD2)
-				|| ChkString(CdromLabel, "SLPS02480", strlen("SLPS02480")) // PARASITE EVE II (2DISCS)
-				|| ChkString(CdromLabel, "SLPS02481", strlen("SLPS02481")) // PARASITE EVE II (2DISCS)
-                || ChkString(CdromLabel, "SLUS00447", strlen("SLUS00447")) // VANDAL HEARTS
-				|| ChkString(CdromLabel, "SLUS00940", strlen("SLUS00940"))) // VANDAL HEARTS II
-			{
-		        Config.RCntFix = 1;
-		    }
-			if (ChkString(CdromLabel, "Vandal Hearts", strlen("Vandal Hearts"))) {
-		        Config.RCntFix = 1;
-		    }
-			// add xjsxjs197 end
 			sprintf(buffer,"CD-ROM ID: %s\n", CdromId);
 			strcat(RomInfo,buffer);
+			// add xjsxjs197 start
+			// check timing fix
+			CheckGameAutoFix();
 			if (Config.RCntFix)
-            {
-                sprintf(buffer, "TIMING FIX: Yes\n");
-            }
-            else
-            {
-                sprintf(buffer, "TIMING FIX: No\n");
-            }
+            		{
+                		sprintf(buffer, "RCnt2 auto fixed\n");
+            		}
+			CheckGameGPUBusyAutoFix();
+            		if (dwEmuFixes)
+            		{
+                		sprintf(buffer, "GPU 'Fake Busy States' hacked\n");
+            		}
+			// auto recJR => psxJR for some game
+			CheckGameR3000AutoFix();
+			if (Config.pR3000Fix)
+            		{
+                		sprintf(buffer, "pR3000 auto fixed\n");
+			}
+			// add xjsxjs197 end
 			strcat(RomInfo,buffer);
 			sprintf(buffer,"CD size: %u Mb\n",isoFile.size/1024/1024);
 			strcat(RomInfo,buffer);

--- a/Gamecube/menu/FileBrowserFrame.cpp
+++ b/Gamecube/menu/FileBrowserFrame.cpp
@@ -617,11 +617,13 @@ void fileBrowserFrame_LoadFile(int i)
 			strcat(RomInfo,feedback_string);
 			sprintf(buffer,"\nCD-ROM Label: %s\n",CdromLabel);
 			strcat(RomInfo,buffer);
+			// add xjsxjs197 start
+			CheckGameAutoFix();
+			// add xjsxjs197 end
 			sprintf(buffer,"CD-ROM ID: %s\n", CdromId);
 			strcat(RomInfo,buffer);
 			// add xjsxjs197 start
 			// check timing fix
-			CheckGameAutoFix();
 			if (Config.RCntFix)
             		{
                 		sprintf(buffer, "RCnt2 auto fixed\n");
@@ -645,7 +647,6 @@ void fileBrowserFrame_LoadFile(int i)
 				strcat(RomInfo,buffer);
 			}
 			// add xjsxjs197 end
-			strcat(RomInfo,buffer);
 			sprintf(buffer,"CD size: %u Mb\n",isoFile.size/1024/1024);
 			strcat(RomInfo,buffer);
 			sprintf(buffer,"Region: %s\n",(!Config.PsxType) ? "NTSC":"PAL");

--- a/Gamecube/menu/FileBrowserFrame.cpp
+++ b/Gamecube/menu/FileBrowserFrame.cpp
@@ -625,10 +625,12 @@ void fileBrowserFrame_LoadFile(int i)
 			if (Config.RCntFix)
             		{
                 		sprintf(buffer, "RCnt2 auto fixed\n");
+				strcat(RomInfo,buffer);
             		}
             		if (dwEmuFixes)
             		{
                 		sprintf(buffer, "GPU 'Fake Busy States' hacked\n");
+				strcat(RomInfo,buffer);
             		}
 			if (dwActFixes)
 			{
@@ -640,6 +642,7 @@ void fileBrowserFrame_LoadFile(int i)
 			if (Config.pR3000Fix)
             		{
                 		sprintf(buffer, "pR3000 auto fixed\n");
+				strcat(RomInfo,buffer);
 			}
 			// add xjsxjs197 end
 			strcat(RomInfo,buffer);

--- a/PeopsSoftGPU/gpu.c
+++ b/PeopsSoftGPU/gpu.c
@@ -1439,8 +1439,8 @@ ENDVRAM:
        gpuDataC=gpuDataP=0;
        primFunc[gpuCommand]((unsigned char *)gpuDataM);
 
-//       if(dwEmuFixes&0x0001 || dwActFixes&0x0400)      // hack for emulating "gpu busy" in some games
-//        iFakePrimBusy=4;
+       if(dwEmuFixes&0x0001 || dwActFixes&0x0400)      // hack for emulating "gpu busy" in some games
+        iFakePrimBusy=4;
       }
     }
   }

--- a/gpu.h
+++ b/gpu.h
@@ -29,6 +29,9 @@
 #define PSXGPU_ILACE   (1<<22)
 #define PSXGPU_DHEIGHT (1<<19)
 
+#define GPUSTATUS_READYFORVRAM        0x08000000
+#define GPUSTATUS_IDLE                0x04000000
+
 // both must be set for interlace to work
 #define PSXGPU_ILACE_BITS (PSXGPU_ILACE | PSXGPU_DHEIGHT)
 

--- a/psxcommon.h
+++ b/psxcommon.h
@@ -115,6 +115,7 @@ typedef struct {
 	long RCntFix;
 	long UseNet;
 	long VSyncWA;
+	long pR3000Fix;
 } PcsxConfig;
 
 extern PcsxConfig Config;

--- a/psxcounters.c
+++ b/psxcounters.c
@@ -511,7 +511,8 @@ u32 psxRcntRcount( u32 index )
         {
             if( rcnts[index].counterState == CountToTarget )
             {
-                count /= BIAS;
+                //count /= BIAS;
+                count = count >> 1;
             }
         }
     }

--- a/psxcounters.c
+++ b/psxcounters.c
@@ -191,6 +191,8 @@ extern int rc0Index;
 extern int dispHeight;
 extern unsigned long dwFrameRateTicks;
 extern unsigned long newDwFrameRateTicks;
+// hack for emulating "gpu busy" in some games
+extern unsigned long dwEmuFixes;
 
 static
 void _psxRcntWmode( u32 index, u32 value )
@@ -397,7 +399,7 @@ void psxRcntUpdate()
 //
             #ifdef SHOW_DEBUG
             //sprintf(txtbuffer, "VBlankStart gteCycle %ld gteTicks %d\n", psxRegs.gteCycle, curGteTicks);
-            sprintf(txtbuffer, "DispHeight %d rcnt0 rate %f \n", dispHeight, rcnts[0].rateF);
+            sprintf(txtbuffer, "DispHeight %d rcnt0 rate %f dwEmuFixes %d \n", dispHeight, rcnts[0].rateF, dwEmuFixes);
             DEBUG_print(txtbuffer, DBG_CORE1);
             writeLogFile(txtbuffer);
             #endif // DISP_DEBUG


### PR DESCRIPTION
This huge PR has these changes:

* Tidy up the system timing autoFix, add more game IDs to system timing autoFix (based on https://github.com/xjsxjs197/WiiSXRX_2022/commit/14c7f350d1190065fcfa4a04be1a0d85d4a236bc)
* Add GPU 'Fake Busy States' emulation hack, including an autoFix for this - fixes Hot Wheels: Turbo Racing and some others (based on https://github.com/xjsxjs197/WiiSXRX_2022/commit/bf10d88aee42c23560a08a0dad1f23ecaf25ed88)
* Add more autoFixes (for system timing, pR3000A, special game corrections) - fixes some games such Supercross 2000, Star Wars: Dark Forces (from https://github.com/xjsxjs197/WiiSXRX_2022/commit/ecd5288aff9678184e959f0579b0e0a066801019 ; https://github.com/xjsxjs197/WiiSXRX_2022/commit/27c4bd1552257a3657c37ce7139087dbf0ea89f4 )
* Fix the system timing autoFix being broken since 3.2 (from https://github.com/xjsxjs197/WiiSXRX_2022/commit/d5df2fbc2f2799b351862ae496c26e29a1e66da0 ; hotfix for 3.2 can be seen also on https://github.com/niuus/WiiSXRX/pull/79)

The most hardest to do in this PR was the variables and calls for call to check if the game IDs has an autoFix, because i tried copying and pasting the code but it didn't compile in r26.
What i did is take the old autoFix code as base for make the same database but that it can be compiled on r26, so these work now also on WiiSXRX.

Hope you merge this soon for 3.3. :)

@saulfabregwiivc