### PR TITLE
Fix Dithering setting saving (at last)

### DIFF
--- a/Gamecube/GamecubeMain.cpp
+++ b/Gamecube/GamecubeMain.cpp
@@ -100,6 +100,7 @@ char biosDevice;
 char LoadCdBios=0;
 char frameLimit;
 char frameSkip;
+char useDithering;
 extern char audioEnabled;
 char volume;
 char showFPSonScreen;
@@ -157,6 +158,7 @@ static struct {
   { "BootThruBios", &LoadCdBios, BOOTTHRUBIOS_NO, BOOTTHRUBIOS_YES },
   { "LimitFrames", &frameLimit, FRAMELIMIT_NONE, FRAMELIMIT_AUTO },
   { "SkipFrames", &frameSkip, FRAMESKIP_DISABLE, FRAMESKIP_ENABLE },
+  { "Dithering", &useDithering, USEDITHER_NONE, USEDITHER_ALWAYS },
   { "PadAutoAssign", &padAutoAssign, PADAUTOASSIGN_MANUAL, PADAUTOASSIGN_AUTOMATIC },
   { "PadType1", &padType[0], PADTYPE_NONE, PADTYPE_WII },
   { "PadType2", &padType[1], PADTYPE_NONE, PADTYPE_WII },
@@ -190,7 +192,7 @@ void loadSettings(int argc, char *argv[])
 	printToSD        = 0; // Disable SD logging
 	frameLimit		 = 1; // Auto limit FPS
 	frameSkip		 = 0; // Disable frame skipping
-	iUseDither		 = 1; // Default dithering
+	UseDithering		 = 1; // Default dithering (set to 0 (disabled) in PEOPSgpu)
 	saveEnabled      = 0; // Don't save game
 	nativeSaveDevice = 0; // SD
 	saveStateDevice	 = 0; // SD
@@ -335,6 +337,7 @@ void loadSettings(int argc, char *argv[])
 
 	//Synch settings with Config
 	Config.Cpu=dynacore;
+	iUseDither = useDithering;
 	iVolume = volume;
 }
 

--- a/Gamecube/GamecubeMain.cpp
+++ b/Gamecube/GamecubeMain.cpp
@@ -192,7 +192,7 @@ void loadSettings(int argc, char *argv[])
 	printToSD        = 0; // Disable SD logging
 	frameLimit		 = 1; // Auto limit FPS
 	frameSkip		 = 0; // Disable frame skipping
-	UseDithering		 = 1; // Default dithering (set to 0 (disabled) in PEOPSgpu)
+	useDithering		 = 1; // Default dithering (set to 0 (disabled) in PEOPSgpu)
 	saveEnabled      = 0; // Don't save game
 	nativeSaveDevice = 0; // SD
 	saveStateDevice	 = 0; // SD

--- a/Gamecube/menu/SettingsFrame.cpp
+++ b/Gamecube/menu/SettingsFrame.cpp
@@ -1027,6 +1027,7 @@ void Func_DitheringNone()
 		FRAME_BUTTONS[i].button->setSelected(false);
 	FRAME_BUTTONS[25].button->setSelected(true);
 	iUseDither = USEDITHER_NONE;
+	useDithering = iUseDither;
 	GPUsetframelimit(0);
 }
 
@@ -1036,6 +1037,7 @@ void Func_DitheringDefault()
 		FRAME_BUTTONS[i].button->setSelected(false);
 	FRAME_BUTTONS[26].button->setSelected(true);
 	iUseDither = USEDITHER_DEFAULT;
+	useDithering = iUseDither;
 	GPUsetframelimit(0);
 }
 
@@ -1045,6 +1047,7 @@ void Func_DitheringAlways()
 		FRAME_BUTTONS[i].button->setSelected(false);
 	FRAME_BUTTONS[27].button->setSelected(true);
 	iUseDither = USEDITHER_ALWAYS;
+	useDithering = iUseDither;
 	GPUsetframelimit(0);
 }
 

--- a/Gamecube/wiiSXconfig.h
+++ b/Gamecube/wiiSXconfig.h
@@ -90,6 +90,7 @@ enum frameSkip
 };
 
 extern int iUseDither;
+extern char useDithering;
 enum iUseDither
 {
 	USEDITHER_NONE=0,

--- a/PeopsSoftGPU/cfg.c
+++ b/PeopsSoftGPU/cfg.c
@@ -333,7 +333,7 @@ void ReadConfig(void)
  dwCfgFixes=0;
  iUseFixes=0;
  iUseNoStretchBlt=1;
- iUseDither=0;
+ iUseDither = useDithering;
  iShowFPS=0;
  bSSSPSXLimit=FALSE;
 


### PR DESCRIPTION
This issue since the very beginning has always plagued the WiiSX family (WiiSX/-R/-RX/WiiStation), so it's time to finally get rid of this problem and finally fix it.

Added a setting in settingsRX.cfg file so Dithering can be modified manually, and will be saved and loaded correctly.

Valid values for Dithering setting (**Dithering =**):
0 = no dithering (None)
1 = default (by default is set to No dithering in PEOPS GPU)
2 = always use dithering (Always)

Reading your comment in your thread https://gbatemp.net/threads/wiisx-rx-a-new-fork.570252:

> **Quote from niuus:**
> Original had an annoying bug with Dithering being always ON by default, even if you saved the configuration. This fixes it, benefiting with a good speedup for some games without having to always change it at boot (i.e. Castlevania: Symphony of the Night gains 16fps just on the "Select your Destiny" screen alone, your mileage may vary per scene and game).

But your fix for that was:
> Correct. Even if you saved the "Off" in the GUI, it was still "On" internally when you load back the emulator, and performance takes a dip, naturally. I made it really "Off" by default.

So i was tired of that annoying bug, so i took this in my hands and made a permanent fix for Dithering setting saving.
Now you can save correctly the Dithering setting, and the emulator will load your saved setting next time you startup the emu.

Cheers! @saulfabregwiivc